### PR TITLE
Improve the usability of CommandView

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -70,6 +70,12 @@ impl<const S: usize> Command<S> {
         apdu.try_into()
     }
 
+    /// Prevent creation of APDU with data larger than u16::MAX, as they cannot be encoded
+    /// ```compile_fail
+    /// let _= iso7816::Command::<65536>::try_from(b"etiuan".as_slice());
+    /// ```
+    const COMPILE_ERROR_LEN: () = assert!(S < u16::MAX as usize);
+
     pub fn class(&self) -> class::Class {
         self.class
     }
@@ -203,6 +209,7 @@ impl<'a> CommandView<'a> {
             data,
             extended,
         } = self;
+        let _ = Command::<S>::COMPILE_ERROR_LEN;
         Ok(Command {
             // header
             class,
@@ -221,6 +228,7 @@ impl<'a> CommandView<'a> {
 impl<const S: usize> TryFrom<&[u8]> for Command<S> {
     type Error = FromSliceError;
     fn try_from(apdu: &[u8]) -> core::result::Result<Self, Self::Error> {
+        let _ = Self::COMPILE_ERROR_LEN;
         let view: CommandView = apdu.try_into()?;
         view.to_owned()
     }

--- a/src/command.rs
+++ b/src/command.rs
@@ -20,7 +20,7 @@ pub struct Command<const S: usize> {
     pub extended: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 /// Memory-efficient unowned version of [`Command`]
 pub struct CommandView<'a> {
     class: class::Class,
@@ -97,6 +97,18 @@ impl<const S: usize> Command<S> {
         self.le
     }
 
+    pub fn as_view(&self) -> CommandView {
+        CommandView {
+            class: self.class,
+            instruction: self.instruction,
+            p1: self.p1,
+            p2: self.p2,
+            data: self.data(),
+            le: self.le,
+            extended: self.extended,
+        }
+    }
+
     /// This can be use for APDU chaining to convert
     /// multiple APDU's into one.
     /// * Global Platform GPC_SPE_055 3.10
@@ -104,6 +116,17 @@ impl<const S: usize> Command<S> {
     pub fn extend_from_command<const T: usize>(
         &mut self,
         command: &Command<T>,
+    ) -> core::result::Result<(), ()> {
+        self.extend_from_command_view(command.as_view())
+    }
+
+    /// This can be use for APDU chaining to convert
+    /// multiple APDU's into one.
+    /// * Global Platform GPC_SPE_055 3.10
+    #[allow(clippy::result_unit_err)]
+    pub fn extend_from_command_view(
+        &mut self,
+        command: CommandView,
     ) -> core::result::Result<(), ()> {
         // Always take the header from the last command;
         self.class = command.class();

--- a/src/command.rs
+++ b/src/command.rs
@@ -35,25 +35,6 @@ pub struct CommandView<'a> {
     pub extended: bool,
 }
 
-// impl<const S: usize> core::borrow::Borrow<CommandView<'a> + 'a> for Command<S> {
-//     fn borrow(&self) -> &CommandView<'a> {
-//         &CommandView {
-//             class: self.class,
-//             instruction: self.instruction,
-//             p1: self.p1,
-//             p2: self.p2,
-//             data: self.data.as_slice(),
-//             le: self.le,
-//             extended: self.extended,
-//         }
-//     }
-// }
-
-// can't implement ToOwned, as
-// a) our conversion is fallible
-// b) our conversion has variable target size
-// impl<'a, S: const usize> ToOwned for CommandView<'a>
-
 impl<'a> CommandView<'a> {
     pub fn class(&self) -> class::Class {
         self.class

--- a/src/command.rs
+++ b/src/command.rs
@@ -9,15 +9,15 @@ pub struct Command<const S: usize> {
     class: class::Class,
     instruction: Instruction,
 
-    pub p1: u8,
-    pub p2: u8,
+    p1: u8,
+    p2: u8,
 
     /// The main reason this is modeled as Bytes and not
     /// a fixed array is for serde purposes.
     data: Data<S>,
 
     le: usize,
-    pub extended: bool,
+    extended: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -26,13 +26,13 @@ pub struct CommandView<'a> {
     class: class::Class,
     instruction: Instruction,
 
-    pub p1: u8,
-    pub p2: u8,
+    p1: u8,
+    p2: u8,
 
     data: &'a [u8],
 
     le: usize,
-    pub extended: bool,
+    extended: bool,
 }
 
 impl<'a> CommandView<'a> {
@@ -50,6 +50,18 @@ impl<'a> CommandView<'a> {
 
     pub fn expected(&self) -> usize {
         self.le
+    }
+
+    pub fn p1(&self) -> u8 {
+        self.p1
+    }
+
+    pub fn p2(&self) -> u8 {
+        self.p2
+    }
+
+    pub fn extended(&self) -> bool {
+        self.extended
     }
 }
 
@@ -88,6 +100,18 @@ impl<const S: usize> Command<S> {
             le: self.le,
             extended: self.extended,
         }
+    }
+
+    pub fn p1(&self) -> u8 {
+        self.p1
+    }
+
+    pub fn p2(&self) -> u8 {
+        self.p2
+    }
+
+    pub fn extended(&self) -> bool {
+        self.extended
     }
 
     /// This can be use for APDU chaining to convert


### PR DESCRIPTION
CommandViews avoid copying the whole content of the commands each time. This patch makes CommandViews more usefull by making them usable with `extend_from_command` by adding a new `extend_from_command_view` method.

It also adds an `as_view` method in `Command<C>` so that APIs that take a `CommandView` can still be used with an `&Command<C>`