### PR TITLE
Add a CommandBuilder API to build APDUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add a command builder API ([#13][])
+
+[#13]: https://github.com/trussed-dev/iso7816/pull/13
+
 ## [0.1.1] - 2022-08-22
 - various fixes @robin-nitrokey @sosthene-nitrokey
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "iso7816"
 version = "0.1.1"
-authors = ["Nicolas Stalder <n@stalder.io>"]
+authors = ["The Trussed developers"]
 edition = "2021"
-repository = "https://github.com/ycrypto/iso7816"
+repository = "https://github.com/trussed-dev/iso7816"
 description = "Types for ISO 7816"
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/iso7816"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/iso7816"
 [dependencies]
 delog = "0.1.2"
 heapless = "0.7"
+heapless-bytes = { version = "0.3.0", optional = true }
 
 [features]
 std = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ documentation = "https://docs.rs/iso7816"
 delog = "0.1.2"
 heapless = "0.7"
 
+[features]
+std = []
+
 [dev-dependencies]
 hex-literal = "0.3.1"
 quickcheck = "1.0.3"

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "iso7816-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+arbitrary = { version = "1.3.0", features = ["derive"] }
+libfuzzer-sys = "0.4"
+
+
+[dependencies.iso7816]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "fuzz_target_1"
+path = "fuzz_targets/fuzz_target_1.rs"
+test = false
+doc = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,6 +14,7 @@ libfuzzer-sys = "0.4"
 
 [dependencies.iso7816]
 path = ".."
+features = ["std"]
 
 # Prevent this from interfering with workspaces
 [workspace]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -28,3 +28,9 @@ name = "fuzz_target_1"
 path = "fuzz_targets/fuzz_target_1.rs"
 test = false
 doc = false
+
+[[bin]]
+name = "fuzz_target_2"
+path = "fuzz_targets/fuzz_target_2.rs"
+test = false
+doc = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -3,6 +3,7 @@ name = "iso7816-fuzz"
 version = "0.0.0"
 publish = false
 edition = "2021"
+license = "Apache-2.0 OR MIT"
 
 [package.metadata]
 cargo-fuzz = true

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -1,0 +1,67 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use arbitrary::Arbitrary;
+use iso7816::command::{class, Command, CommandBuilder, CommandView};
+
+use std::iter::repeat;
+
+#[derive(Debug, Arbitrary)]
+struct Input<'a> {
+    class: u8,
+    instruction: u8,
+    p1: u8,
+    p2: u8,
+    le: u16,
+    buf_len: usize,
+    buf_lens: Vec<usize>,
+    data: &'a [u8],
+}
+
+fuzz_target!(|data: Input| {
+    if data.class == 0b11101111 {
+        // pathological class that can't be chained because it makes it a 0xFF
+        return;
+    }
+    let Ok(class) = class::Class::try_from(data.class) else {
+        return;
+    };
+    let ins = data.instruction.into();
+
+    let buffer = &mut [0; 4096][..data.buf_len.min(4096).max(128)];
+
+    let command = CommandBuilder::new(class, ins, data.p1, data.p2, data.data, data.le);
+    match command.clone().serialize_into(buffer) {
+        Ok(len) => {
+            // dbg!(&buffer[..len][..len]);
+            let view = CommandView::try_from(&buffer[..len]).unwrap();
+            assert_eq!(view, command, "buffer: {:02x?}", &buffer[..len]);
+        }
+        Err((len, mut rem)) => {
+            // dbg!(&buffer[..len]);
+            let mut parsed = Command::<4096>::try_from(&buffer[..len]).unwrap();
+            // Loop with arbitrary buflens forever
+            for buflen in repeat(data.buf_lens.iter().chain([&128])).flatten() {
+                let buffer = &mut [0; 4096][..(*buflen).min(4096).max(128)];
+                match rem.serialize_into(buffer) {
+                    Ok(len) => {
+                        // dbg!(&buffer[..len]);
+                        let view = CommandView::try_from(&buffer[..len]).unwrap();
+                        parsed.extend_from_command_view(view).unwrap();
+                        assert_eq!(command, parsed.as_view());
+                        return;
+                    }
+                    Err((len, new_rem)) => {
+                        // dbg!(&buffer[..len]);
+                        rem = new_rem;
+
+                        let view = CommandView::try_from(&buffer[..len]).unwrap();
+                        parsed.extend_from_command_view(view).unwrap();
+                    }
+                }
+            }
+        }
+    }
+    // fuzzed code goes here
+});

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -3,12 +3,12 @@
 use libfuzzer_sys::fuzz_target;
 
 use arbitrary::Arbitrary;
-use iso7816::command::{class, Command, CommandBuilder, CommandView};
+use iso7816::command::{class, BufferFull, Command, CommandBuilder, CommandView};
 
-use std::convert::Infallible;
 use std::iter::repeat;
 use std::ops::Deref;
 
+#[derive(Debug)]
 struct WriteMock {
     buffer: [u8; 4096],
     written: usize,
@@ -23,17 +23,17 @@ impl Deref for WriteMock {
 }
 
 impl iso7816::command::Writer for WriteMock {
-    type Error = Infallible;
-    fn write(&mut self, data: &[u8]) -> Result<usize, Infallible> {
+    type Error = BufferFull;
+    fn write(&mut self, data: &[u8]) -> Result<usize, BufferFull> {
         let available = self.capacity - self.written;
         let written = available.min(data.len());
-        self.buffer[self.written..][..written].copy_from_slice(data);
+        self.buffer[self.written..][..written].copy_from_slice(&data[..written]);
         self.written += written;
-        Ok(written)
-    }
-
-    fn remaining_len(&self) -> usize {
-        self.capacity - self.written
+        if written == 0 {
+            Err(BufferFull)
+        } else {
+            Ok(written)
+        }
     }
 }
 
@@ -74,7 +74,8 @@ fuzz_target!(|data: Input| {
 
     // Test for the length information
     {
-        command.clone().serialize_to_vec();
+        command.clone().serialize_to_vec(true);
+        command.clone().serialize_to_vec(false);
     }
 
     let mut buffer = WriteMock {
@@ -83,72 +84,161 @@ fuzz_target!(|data: Input| {
         capacity: buf_len.min(4096).max(128),
     };
 
-    match command
-        .clone()
-        .serialize_into(&mut buffer, supports_extended)
-        .unwrap()
-    {
-        Ok(()) => {
-            // dbg!(&*buffer, buffer.len());
+    match command.should_split(buffer.capacity, supports_extended) {
+        None => {
+            command
+                .clone()
+                .serialize_into(&mut buffer, supports_extended)
+                .unwrap();
             let view = CommandView::try_from(&*buffer).unwrap();
             if !supports_extended {
                 assert!(view.data().len() <= 256);
                 assert!(!view.extended());
                 // Without extended support, le is truncated to 256 at max, and the response will come with command chaining
                 let command = CommandBuilder::new(class, ins, p1, p2, data, le.min(256));
-                assert_eq!(command, view);
+                assert_eq!(view, command);
             } else {
                 assert_eq!(view, command);
             }
         }
-
-        Err(mut rem) => {
-            let len = buffer.len();
-            // dbg!(&*buffer, buffer.len());
-            let mut parsed = Command::<4096>::try_from(&buffer[..len]).unwrap();
+        Some((current_command, mut remaining_command)) => {
+            current_command
+                .clone()
+                .serialize_into(&mut buffer, supports_extended)
+                .unwrap();
+            let mut parsed_command: iso7816::Command<4096> = Command::try_from(&buffer).unwrap();
             if !supports_extended {
-                assert!(parsed.data().len() <= 255);
-                assert!(!parsed.extended());
+                assert!(parsed_command.data().len() <= 256);
+                assert!(!parsed_command.extended());
+                assert_eq!(parsed_command.as_view(), current_command);
+            } else {
+                assert_eq!(parsed_command.as_view(), current_command);
             }
-            // Loop with arbitrary buflens forever
-            for buflen in repeat(buf_lens.iter().chain([&128])).flatten() {
+
+            for buf_len in repeat(
+                buf_lens
+                    .into_iter()
+                    .map(|l| l.min(4096).max(128))
+                    .chain([128]),
+            )
+            .flatten()
+            {
                 let mut buffer = WriteMock {
                     buffer: [0; 4096],
                     written: 0,
-                    capacity: (*buflen).min(4096).max(128),
+                    capacity: buf_len.min(4096).max(128),
                 };
-                match rem.serialize_into(&mut buffer, supports_extended).unwrap() {
-                    Ok(()) => {
-                        // dbg!(&*buffer, buffer.len());
-                        let view = CommandView::try_from(&*buffer).unwrap();
-                        if !supports_extended {
-                            assert!(view.data().len() <= 255);
-                            assert!(!view.extended());
-                        }
-                        parsed.extend_from_command_view(view).unwrap();
-                        if supports_extended {
-                            assert_eq!(command, parsed.as_view());
-                        } else {
-                            // Without extended support, le is truncated to 255 at max, and the response will come with command chaining
-                            let command =
-                                CommandBuilder::new(class, ins, p1, p2, data, le.min(256));
-                            assert_eq!(command, parsed.as_view());
-                        }
-                        return;
-                    }
-                    Err(new_rem) => {
-                        rem = new_rem;
 
-                        let view = CommandView::try_from(&*buffer).unwrap();
-                        if !supports_extended {
-                            assert!(view.data().len() <= 255);
-                            assert!(!view.extended());
-                        }
-                        parsed.extend_from_command_view(view).unwrap();
+                let Some((left, rem)) = remaining_command.should_split(buf_len, supports_extended) else {
+
+                    remaining_command.clone().serialize_into(&mut buffer, supports_extended).unwrap();
+
+                    let view = CommandView::try_from(&*buffer).unwrap();
+                    if !supports_extended {
+                        assert!(view.data().len() <= 256);
+                        assert!(!view.extended());
+                        assert_eq!(view, remaining_command);
+                    } else {
+                        assert_eq!(view, remaining_command);
                     }
+                    parsed_command.extend_from_command_view(view).unwrap();
+                    let view = parsed_command.as_view();
+
+                    if !supports_extended {
+                        // Without extended support, le is truncated to 256 at max, and the response will come with command chaining
+                        let command = CommandBuilder::new(class, ins, p1, p2, data, le.min(256));
+                        assert_eq!(view, command);
+                    } else {
+                        assert_eq!(view, command);
+                    }
+
+                    break;
+                };
+                remaining_command = rem;
+
+                left.clone()
+                    .serialize_into(&mut buffer, supports_extended)
+                    .unwrap();
+                let view = CommandView::try_from(&*buffer).unwrap();
+                if !supports_extended {
+                    assert!(view.data().len() <= 256);
+                    assert!(!view.extended());
+                    assert_eq!(view, left);
+                } else {
+                    assert_eq!(view, left);
                 }
+
+                parsed_command.extend_from_command_view(view).unwrap();
             }
         }
     }
+
+    // match command
+    //     .clone()
+    //     .serialize_into(&mut buffer, supports_extended)
+    //     .unwrap()
+    // {
+    //     Ok(()) => {
+    //         // dbg!(&*buffer, buffer.len());
+    //         let view = CommandView::try_from(&*buffer).unwrap();
+    //         if !supports_extended {
+    //             assert!(view.data().len() <= 256);
+    //             assert!(!view.extended());
+    //             // Without extended support, le is truncated to 256 at max, and the response will come with command chaining
+    //             let command = CommandBuilder::new(class, ins, p1, p2, data, le.min(256));
+    //             assert_eq!(command, view);
+    //         } else {
+    //             assert_eq!(view, command);
+    //         }
+    //     }
+
+    //     Err(mut rem) => {
+    //         let len = buffer.len();
+    //         // dbg!(&*buffer, buffer.len());
+    //         let mut parsed = Command::<4096>::try_from(&buffer[..len]).unwrap();
+    //         if !supports_extended {
+    //             assert!(parsed.data().len() <= 255);
+    //             assert!(!parsed.extended());
+    //         }
+    //         // Loop with arbitrary buflens forever
+    //         for buflen in repeat(buf_lens.iter().chain([&128])).flatten() {
+    //             let mut buffer = WriteMock {
+    //                 buffer: [0; 4096],
+    //                 written: 0,
+    //                 capacity: (*buflen).min(4096).max(128),
+    //             };
+    //             match rem.serialize_into(&mut buffer, supports_extended).unwrap() {
+    //                 Ok(()) => {
+    //                     // dbg!(&*buffer, buffer.len());
+    //                     let view = CommandView::try_from(&*buffer).unwrap();
+    //                     if !supports_extended {
+    //                         assert!(view.data().len() <= 255);
+    //                         assert!(!view.extended());
+    //                     }
+    //                     parsed.extend_from_command_view(view).unwrap();
+    //                     if supports_extended {
+    //                         assert_eq!(command, parsed.as_view());
+    //                     } else {
+    //                         // Without extended support, le is truncated to 255 at max, and the response will come with command chaining
+    //                         let command =
+    //                             CommandBuilder::new(class, ins, p1, p2, data, le.min(256));
+    //                         assert_eq!(command, parsed.as_view());
+    //                     }
+    //                     return;
+    //                 }
+    //                 Err(new_rem) => {
+    //                     rem = new_rem;
+
+    //                     let view = CommandView::try_from(&*buffer).unwrap();
+    //                     if !supports_extended {
+    //                         assert!(view.data().len() <= 255);
+    //                         assert!(!view.extended());
+    //                     }
+    //                     parsed.extend_from_command_view(view).unwrap();
+    //                 }
+    //             }
+    //         }
+    //     }
+    // }
     // fuzzed code goes here
 });

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -55,7 +55,7 @@ fuzz_target!(|data: Input| {
             let view = CommandView::try_from(&buffer[..len]).unwrap();
             if !supports_extended {
                 assert!(view.data().len() <= 255);
-                assert_eq!(view.extended(), false);
+                assert!(!view.extended());
                 // Without extended support, le is truncated to 255 at max, and the response will come with command chaining
                 let command = CommandBuilder::new(class, ins, p1, p2, data, le.min(255));
                 assert_eq!(command, view);
@@ -68,7 +68,7 @@ fuzz_target!(|data: Input| {
             let mut parsed = Command::<4096>::try_from(&buffer[..len]).unwrap();
             if !supports_extended {
                 assert!(parsed.data().len() <= 255);
-                assert_eq!(parsed.extended(), false);
+                assert!(!parsed.extended());
             }
             // Loop with arbitrary buflens forever
             for buflen in repeat(buf_lens.iter().chain([&128])).flatten() {
@@ -79,7 +79,7 @@ fuzz_target!(|data: Input| {
                         let view = CommandView::try_from(&buffer[..len]).unwrap();
                         if !supports_extended {
                             assert!(view.data().len() <= 255);
-                            assert_eq!(view.extended(), false);
+                            assert!(!view.extended());
                         }
                         parsed.extend_from_command_view(view).unwrap();
                         if supports_extended {
@@ -99,7 +99,7 @@ fuzz_target!(|data: Input| {
                         let view = CommandView::try_from(&buffer[..len]).unwrap();
                         if !supports_extended {
                             assert!(view.data().len() <= 255);
-                            assert_eq!(view.extended(), false);
+                            assert!(!view.extended());
                         }
                         parsed.extend_from_command_view(view).unwrap();
                     }

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -40,10 +40,15 @@ fuzz_target!(|data: Input| {
         return;
     };
     let ins = instruction.into();
+    let command = CommandBuilder::new(class, ins, p1, p2, data, le);
+
+    // Test for the length information
+    {
+        command.clone().serialize_to_vec();
+    }
 
     let buffer = &mut [0; 4096][..buf_len.min(4096).max(128)];
 
-    let command = CommandBuilder::new(class, ins, p1, p2, data, le);
     match command.clone().serialize_into(buffer, supports_extended) {
         Ok(len) => {
             // dbg!(&buffer[..len][..len]);

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -45,6 +45,7 @@ struct Input<'a> {
     le: u16,
     buf_len: usize,
     supports_extended: bool,
+    force_extended: bool,
     data: &'a [u8],
 }
 
@@ -57,6 +58,7 @@ fuzz_target!(|data: Input| {
         mut le,
         mut buf_len,
         supports_extended,
+        force_extended,
         data,
     } = data;
     if class == 0b11101111 {
@@ -75,7 +77,10 @@ fuzz_target!(|data: Input| {
 
     let ins = instruction.into();
 
-    let command = CommandBuilder::new(class, ins, p1, p2, data, le);
+    let mut command = CommandBuilder::new(class, ins, p1, p2, data, le);
+    if force_extended && supports_extended {
+        command = command.force_extended();
+    }
     // Test for the length information
     {
         command.clone().serialize_to_vec();

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -30,7 +30,7 @@ impl iso7816::command::Writer for WriteMock {
         self.buffer[self.written..][..written].copy_from_slice(&data[..written]);
         self.written += written;
         if written == 0 {
-            Err(BufferFull)
+            Err(BufferFull::BufferFull)
         } else {
             Ok(written)
         }

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -54,10 +54,10 @@ fuzz_target!(|data: Input| {
             // dbg!(&buffer[..len][..len]);
             let view = CommandView::try_from(&buffer[..len]).unwrap();
             if !supports_extended {
-                assert!(view.data().len() <= 255);
+                assert!(view.data().len() <= 256);
                 assert!(!view.extended());
-                // Without extended support, le is truncated to 255 at max, and the response will come with command chaining
-                let command = CommandBuilder::new(class, ins, p1, p2, data, le.min(255));
+                // Without extended support, le is truncated to 256 at max, and the response will come with command chaining
+                let command = CommandBuilder::new(class, ins, p1, p2, data, le.min(256));
                 assert_eq!(command, view);
             } else {
                 assert_eq!(view, command);
@@ -87,7 +87,7 @@ fuzz_target!(|data: Input| {
                         } else {
                             // Without extended support, le is truncated to 255 at max, and the response will come with command chaining
                             let command =
-                                CommandBuilder::new(class, ins, p1, p2, data, le.min(255));
+                                CommandBuilder::new(class, ins, p1, p2, data, le.min(256));
                             assert_eq!(command, parsed.as_view());
                         }
                         return;

--- a/fuzz/fuzz_targets/fuzz_target_2.rs
+++ b/fuzz/fuzz_targets/fuzz_target_2.rs
@@ -1,0 +1,54 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+use arbitrary::Arbitrary;
+use iso7816::command::{class, CommandBuilder, CommandView};
+
+#[derive(Debug, Arbitrary)]
+struct Input<'a> {
+    class_1: u8,
+    instruction_1: u8,
+    p1_1: u8,
+    p2_1: u8,
+    le_1: u16,
+    class_2: u8,
+    instruction_2: u8,
+    p1_2: u8,
+    p2_2: u8,
+    le_2: u16,
+    data_1: &'a [u8],
+}
+
+fuzz_target!(|data: Input| {
+    let Input {
+        class_1,
+        instruction_1,
+        p1_1,
+        p2_1,
+        le_1,
+        data_1,
+        class_2,
+        instruction_2,
+        p1_2,
+        p2_2,
+        le_2,
+    } = data;
+    let Ok(class_1) = class::Class::try_from(class_1) else {
+        return;
+    };
+    let Ok(class_2) = class::Class::try_from(class_2) else {
+        return;
+    };
+
+    let inner = CommandBuilder::new(class_1, instruction_1.into(), p1_1, p2_1, data_1, le_1);
+    let outer = CommandBuilder::new(class_2, instruction_2.into(), p1_2, p2_2, &inner, le_2);
+    let res = outer.serialize_to_vec();
+    let view = CommandView::try_from(&*res).unwrap();
+    let inner_view = CommandView::try_from(view.data()).unwrap();
+    assert_eq!(inner_view, inner);
+
+    let outer_ref =
+        CommandBuilder::new(class_2, instruction_2.into(), p1_2, p2_2, view.data(), le_2);
+    assert_eq!(view, outer_ref);
+});

--- a/src/command.rs
+++ b/src/command.rs
@@ -859,7 +859,10 @@ mod test {
         command.serialize_into(&mut buffer).unwrap();
         assert_eq!(buffer.len(), 105);
         rem.supports_extended_length = true;
-        assert_eq!(rem, CommandBuilder::new(cla, ins, 2, 3, &[5; 100], 0));
+        assert_eq!(
+            rem,
+            CommandBuilder::new(cla, ins, 2, 3, [5; 100].as_slice(), 0)
+        );
         assert_eq!(
             &*buffer,
             &CommandBuilder::new(cla.as_chained(), ins, 2, 3, &[5; 100], 0).serialize_to_vec()

--- a/src/command.rs
+++ b/src/command.rs
@@ -227,6 +227,10 @@ impl<'a> CommandBuilder<'a> {
         }
     }
 
+    pub fn data(&self) -> &'a [u8] {
+        self.data
+    }
+
     fn header_data(&self) -> BuildingHeaderData {
         /// Returns (data, len of data, and is_extended)
         fn serialize_data_len(len: u16, expected_len: u16) -> (heapless::Vec<u8, 3>, bool) {

--- a/src/command.rs
+++ b/src/command.rs
@@ -281,7 +281,7 @@ impl<'a, D: DataSource + ?Sized> CommandBuilder<'a, D> {
 
     /// This assumes that the writer has enough space to encode the APDU.
     /// If that might not be the case, first use [`should_split`](Self::should_split)
-    pub fn serialize_into<W: Writer>(self, writer: &mut W) -> Result<(), W::Error>
+    pub fn serialize_into<W: Writer>(&self, writer: &mut W) -> Result<(), W::Error>
     where
         D: DataStream<W>,
     {
@@ -416,6 +416,22 @@ impl<'a> CommandBuilder<'a, [u8]> {
             supports_extended_length: self.supports_extended_length,
         };
         Some((send_now, send_later))
+    }
+}
+
+impl<'a, D: DataSource + ?Sized> DataSource for CommandBuilder<'a, D> {
+    fn len(&self) -> usize {
+        self.required_len()
+    }
+
+    fn is_empty(&self) -> bool {
+        false
+    }
+}
+
+impl<'a, W: Writer, D: DataStream<W> + ?Sized> DataStream<W> for CommandBuilder<'a, D> {
+    fn to_writer(&self, writer: &mut W) -> Result<(), <W as Writer>::Error> {
+        self.serialize_into(writer)
     }
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -15,8 +15,8 @@ pub struct Command<const S: usize> {
     class: class::Class,
     instruction: Instruction,
 
-    p1: u8,
-    p2: u8,
+    pub p1: u8,
+    pub p2: u8,
 
     /// The main reason this is modeled as Bytes and not
     /// a fixed array is for serde purposes.
@@ -63,14 +63,6 @@ impl<const S: usize> Command<S> {
         }
     }
 
-    pub fn p1(&self) -> u8 {
-        self.p1
-    }
-
-    pub fn p2(&self) -> u8 {
-        self.p2
-    }
-
     pub fn extended(&self) -> bool {
         self.extended
     }
@@ -113,8 +105,8 @@ pub struct CommandView<'a> {
     class: class::Class,
     instruction: Instruction,
 
-    p1: u8,
-    p2: u8,
+    pub p1: u8,
+    pub p2: u8,
 
     data: &'a [u8],
 
@@ -139,14 +131,6 @@ impl<'a> CommandView<'a> {
         self.le
     }
 
-    pub fn p1(&self) -> u8 {
-        self.p1
-    }
-
-    pub fn p2(&self) -> u8 {
-        self.p2
-    }
-
     pub fn extended(&self) -> bool {
         self.extended
     }
@@ -157,8 +141,8 @@ pub struct CommandBuilder<'a> {
     class: class::Class,
     instruction: Instruction,
 
-    p1: u8,
-    p2: u8,
+    pub p1: u8,
+    pub p2: u8,
 
     data: &'a [u8],
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -738,6 +738,12 @@ mod test {
             .copied()
             .collect::<Vec<u8>>()
         );
+
+        let command = CommandBuilder::new(cla, ins, 2, 3, &[1, 2, 3, 4], 294);
+        assert_eq!(
+            command.serialize_to_vec(true),
+            &hex!("00 01 02 03 00 00 04 01020304 0126")
+        );
     }
 
     #[test]

--- a/src/command.rs
+++ b/src/command.rs
@@ -25,12 +25,6 @@ impl<const S: usize> Command<S> {
         apdu.try_into()
     }
 
-    /// Prevent creation of APDU with data larger than u16::MAX, as they cannot be encoded
-    /// ```compile_fail
-    /// let _= iso7816::Command::<65536>::try_from(b"etiuan".as_slice());
-    /// ```
-    const COMPILE_ERROR_LEN: () = assert!(S < u16::MAX as usize);
-
     pub fn class(&self) -> class::Class {
         self.class
     }
@@ -261,9 +255,9 @@ impl<'a> CommandBuilder<'a> {
     ///
     /// If the command does not fit in the buffer, fill the buffer with data and return another command
     /// to be send containing the remaining data through command chaining
-    pub fn serialize_into<'buf>(
+    pub fn serialize_into(
         self,
-        buf: &'buf mut [u8],
+        buf: &mut [u8],
         supports_extended_length: bool,
     ) -> Result<usize, (usize, Self)> {
         const HEADER_LEN: usize = 4;
@@ -418,7 +412,6 @@ impl<'a> CommandView<'a> {
             data,
             extended,
         } = self;
-        let _ = Command::<S>::COMPILE_ERROR_LEN;
         Ok(Command {
             // header
             class,
@@ -437,7 +430,6 @@ impl<'a> CommandView<'a> {
 impl<const S: usize> TryFrom<&[u8]> for Command<S> {
     type Error = FromSliceError;
     fn try_from(apdu: &[u8]) -> core::result::Result<Self, Self::Error> {
-        let _ = Self::COMPILE_ERROR_LEN;
         let view: CommandView = apdu.try_into()?;
         view.to_owned()
     }

--- a/src/command.rs
+++ b/src/command.rs
@@ -136,7 +136,7 @@ impl<'a> CommandView<'a> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct CommandBuilder<'a, D: ?Sized> {
     class: class::Class,
     instruction: Instruction,
@@ -148,6 +148,20 @@ pub struct CommandBuilder<'a, D: ?Sized> {
 
     le: u16,
     supports_extended_length: bool,
+}
+
+impl<'a, D: ?Sized> Clone for CommandBuilder<'a, D> {
+    fn clone(&self) -> Self {
+        Self {
+            class: self.class,
+            instruction: self.instruction,
+            p1: self.p1,
+            p2: self.p2,
+            data: self.data,
+            le: self.le,
+            supports_extended_length: self.supports_extended_length,
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -311,7 +325,7 @@ struct BuildingHeaderData {
     expected_data_len: heapless::Vec<u8, 3>,
 }
 
-impl<'a, 'b, D: PartialEq<[u8]>> PartialEq<CommandView<'a>> for CommandBuilder<'b, D> {
+impl<'a, 'b, D: PartialEq<[u8]> + ?Sized> PartialEq<CommandView<'a>> for CommandBuilder<'b, D> {
     fn eq(&self, other: &CommandView<'a>) -> bool {
         let Self {
             class,
@@ -435,7 +449,7 @@ impl<'a, W: Writer, D: DataStream<W> + ?Sized> DataStream<W> for CommandBuilder<
     }
 }
 
-impl<'a, 'b, D: PartialEq<[u8]>> PartialEq<CommandBuilder<'a, D>> for CommandView<'b> {
+impl<'a, 'b, D: PartialEq<[u8]> + ?Sized> PartialEq<CommandBuilder<'a, D>> for CommandView<'b> {
     fn eq(&self, other: &CommandBuilder<'a, D>) -> bool {
         other == self
     }

--- a/src/command.rs
+++ b/src/command.rs
@@ -4,8 +4,11 @@ pub mod class;
 pub mod instruction;
 pub use instruction::Instruction;
 
-mod writer;
+pub mod writer;
 pub use writer::{BufferFull, Writer};
+
+mod datasource;
+pub use datasource::DataSource;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Command<const S: usize> {

--- a/src/command.rs
+++ b/src/command.rs
@@ -183,7 +183,7 @@ impl<'a> CommandBuilder<'a> {
     fn header_data(&self, supports_extended_length: bool) -> BuildingHeaderData {
         /// Returns (data, len of data, and is_extended)
         fn serialize_data_len(len: u16, expected_len: u16) -> (heapless::Vec<u8, 3>, bool) {
-            match (len, expected_len > 255) {
+            match (len, expected_len > 256) {
                 (0, _) => (Default::default(), false),
                 (1..=255, false) => ([len as u8].as_slice().try_into().unwrap(), false),
                 _ => {
@@ -217,7 +217,7 @@ impl<'a> CommandBuilder<'a> {
         let le = if supports_extended_length {
             self.le
         } else {
-            self.le.min(255)
+            self.le.min(256)
         };
 
         // Safe to unwrap because of check in `new`
@@ -644,7 +644,7 @@ mod test {
         assert_eq!(
             command.serialize_to_vec(),
             // Large LE also forces the data length to be extended (can't mix extended/non-extended)
-            &hex!("00 01 02 03 00 00 02 05 06 01 00")
+            &hex!("00 01 02 03 02 05 06 00")
         );
 
         let command = CommandBuilder::new(cla, ins, 2, 3, &[0x01; 0x2AE], 0x100);

--- a/src/command.rs
+++ b/src/command.rs
@@ -870,6 +870,25 @@ mod test {
     }
 
     #[test]
+    fn nested_commands() {
+        let cla = 0x00.try_into().unwrap();
+        let ins = 0x01.into();
+        let mut buffer = heapless::Vec::<u8, 4096>::new();
+        let inner = CommandBuilder::new(cla, ins, 1, 2, &hex!("FFFEFDFCFBFA"), 0x10);
+        let outer = CommandBuilder::new(cla, 0xAA.into(), 3, 4, &inner, 0x20);
+        outer.serialize_into(&mut buffer).unwrap();
+        #[rustfmt::skip]
+        assert_eq!(
+            &*buffer,
+            hex!("
+                00 AA 0304 0C
+                   00 01 01 02 06  FFFEFDFCFBFA 10 
+                20"
+            )
+        );
+    }
+
+    #[test]
     fn lengths_4s() {
         let data = &[0x02, 0xB6, 0x00, 0x00];
         let lengths = parse_lengths(data).expect("failed to parse lengths");

--- a/src/command.rs
+++ b/src/command.rs
@@ -203,7 +203,7 @@ impl From<ExpectedLen> for usize {
     }
 }
 
-impl<'a, D: DataSource> CommandBuilder<D> {
+impl<D: DataSource> CommandBuilder<D> {
     /// Panics if data.len() > u16::MAX
     ///
     /// Assumes that extended length is supported

--- a/src/command.rs
+++ b/src/command.rs
@@ -255,6 +255,7 @@ impl<'a> CommandBuilder<'a> {
         let mut buffer = Vec::with_capacity(required_len);
         self.serialize_into(&mut buffer, supports_extended_length)
             .unwrap();
+        debug_assert_eq!(required_len, buffer.len());
         buffer
     }
 

--- a/src/command/class.rs
+++ b/src/command/class.rs
@@ -158,3 +158,20 @@ impl TryFrom<u8> for Range {
         Ok(range)
     }
 }
+
+pub const ZERO_CLA: Class = Class {
+    cla: 0,
+    range: Range::Interindustry(Interindustry::First),
+};
+
+/// Cla = 0x80
+pub const NO_SM_CLA: Class = Class {
+    cla: 0x80,
+    range: Range::Proprietary,
+};
+
+/// Cla = 0x84
+pub const SM_CLA: Class = Class {
+    cla: 0x84,
+    range: Range::Proprietary,
+};

--- a/src/command/class.rs
+++ b/src/command/class.rs
@@ -91,6 +91,11 @@ impl Class {
         }
     }
 
+    pub fn as_chained(mut self) -> Self {
+        self.cla |= 1 << 4;
+        self
+    }
+
     #[inline]
     pub fn channel(&self) -> Option<u8> {
         Some(match self.range() {

--- a/src/command/class.rs
+++ b/src/command/class.rs
@@ -178,7 +178,7 @@ pub const ZERO_CLA: Class = match Class::from_byte(0x00) {
 };
 
 /// Cla = 0x80
-pub const SM_NO_CLA: Class = match Class::from_byte(0x80) {
+pub const NO_SM_CLA: Class = match Class::from_byte(0x80) {
     Ok(cla) => cla,
     Err(_) => unreachable!(),
 };

--- a/src/command/datasource.rs
+++ b/src/command/datasource.rs
@@ -1,24 +1,59 @@
-/// W is a type parameter of the trait and not the method to make the trait dyn-safe
-#[allow(clippy::len_without_is_empty)]
-pub trait DataSource<W: super::Writer> {
+pub trait DataSource {
+    /// Length of the serialized data
     fn len(&self) -> usize;
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Datasource for APDU serialization
+///
+/// W is a type parameter of the trait and not the method to make the trait dyn-safe
+pub trait DataStream<W: super::Writer>: DataSource {
+    /// Serialize the data to a writer.
+    ///
+    /// The length of the data serialized to the writer must not exceed the value returned by `len`.
     fn to_writer(&self, writer: &mut W) -> Result<(), W::Error>;
 }
 
-impl<W: super::Writer> DataSource<W> for &[u8] {
+impl DataSource for [u8] {
     fn len(&self) -> usize {
         <[u8]>::len(self)
     }
+
+    fn is_empty(&self) -> bool {
+        <[u8]>::is_empty(&self)
+    }
+}
+
+impl<W: super::Writer> DataStream<W> for [u8] {
     fn to_writer(&self, writer: &mut W) -> Result<(), W::Error> {
         writer.write_all(self)
     }
 }
 
-impl<W: super::Writer> DataSource<W> for [&dyn DataSource<W>] {
+impl DataSource for [&dyn DataSource] {
     fn len(&self) -> usize {
         self.iter().map(|item| item.len()).sum()
     }
 
+    fn is_empty(&self) -> bool {
+        self.iter().find(|item| !item.is_empty()).is_some()
+    }
+}
+
+impl<W: super::Writer> DataSource for [&dyn DataStream<W>] {
+    fn len(&self) -> usize {
+        self.iter().map(|item| item.len()).sum()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.iter().find(|item| !item.is_empty()).is_some()
+    }
+}
+
+impl<W: super::Writer> DataStream<W> for [&dyn DataStream<W>] {
     fn to_writer(&self, writer: &mut W) -> Result<(), W::Error> {
         for item in self {
             item.to_writer(writer)?;

--- a/src/command/datasource.rs
+++ b/src/command/datasource.rs
@@ -1,0 +1,28 @@
+/// W is a type parameter of the trait and not the method to make the trait dyn-safe
+#[allow(clippy::len_without_is_empty)]
+pub trait DataSource<W: super::Writer> {
+    fn len(&self) -> usize;
+    fn to_writer(&self, writer: &mut W) -> Result<(), W::Error>;
+}
+
+impl<W: super::Writer> DataSource<W> for &[u8] {
+    fn len(&self) -> usize {
+        <[u8]>::len(self)
+    }
+    fn to_writer(&self, writer: &mut W) -> Result<(), W::Error> {
+        writer.write_all(self)
+    }
+}
+
+impl<W: super::Writer> DataSource<W> for [&dyn DataSource<W>] {
+    fn len(&self) -> usize {
+        self.iter().map(|item| item.len()).sum()
+    }
+
+    fn to_writer(&self, writer: &mut W) -> Result<(), W::Error> {
+        for item in self {
+            item.to_writer(writer)?;
+        }
+        Ok(())
+    }
+}

--- a/src/command/datasource.rs
+++ b/src/command/datasource.rs
@@ -17,6 +17,22 @@ pub trait DataStream<W: super::Writer>: DataSource {
     fn to_writer(&self, writer: &mut W) -> Result<(), W::Error>;
 }
 
+impl<const N: usize> DataSource for [u8; N] {
+    fn len(&self) -> usize {
+        N
+    }
+
+    fn is_empty(&self) -> bool {
+        N == 0
+    }
+}
+
+impl<W: super::Writer, const N: usize> DataStream<W> for [u8; N] {
+    fn to_writer(&self, writer: &mut W) -> Result<(), W::Error> {
+        writer.write_all(self)
+    }
+}
+
 impl DataSource for [u8] {
     fn len(&self) -> usize {
         <[u8]>::len(self)

--- a/src/command/datasource.rs
+++ b/src/command/datasource.rs
@@ -39,7 +39,7 @@ impl DataSource for [u8] {
     }
 
     fn is_empty(&self) -> bool {
-        <[u8]>::is_empty(&self)
+        <[u8]>::is_empty(self)
     }
 }
 
@@ -55,7 +55,7 @@ impl DataSource for [&dyn DataSource] {
     }
 
     fn is_empty(&self) -> bool {
-        self.iter().find(|item| !item.is_empty()).is_some()
+        self.iter().all(|item| item.is_empty())
     }
 }
 
@@ -65,7 +65,7 @@ impl<W: super::Writer> DataSource for [&dyn DataStream<W>] {
     }
 
     fn is_empty(&self) -> bool {
-        self.iter().find(|item| !item.is_empty()).is_some()
+        self.iter().all(|item| !item.is_empty())
     }
 }
 

--- a/src/command/datasource.rs
+++ b/src/command/datasource.rs
@@ -77,3 +77,22 @@ impl<W: super::Writer> DataStream<W> for [&dyn DataStream<W>] {
         Ok(())
     }
 }
+
+impl<I: DataSource> DataSource for Option<I> {
+    fn len(&self) -> usize {
+        self.as_ref().map(DataSource::len).unwrap_or(0)
+    }
+    fn is_empty(&self) -> bool {
+        self.as_ref().map(DataSource::is_empty).unwrap_or(true)
+    }
+}
+
+impl<W: super::Writer, I: DataStream<W>> DataStream<W> for Option<I> {
+    fn to_writer(&self, writer: &mut W) -> Result<(), <W as super::Writer>::Error> {
+        if let Some(inner) = self {
+            inner.to_writer(writer)
+        } else {
+            Ok(())
+        }
+    }
+}

--- a/src/command/datasource.rs
+++ b/src/command/datasource.rs
@@ -97,6 +97,22 @@ impl<W: super::Writer, I: DataStream<W>> DataStream<W> for Option<I> {
     }
 }
 
+impl DataSource for () {
+    fn len(&self) -> usize {
+        0
+    }
+
+    fn is_empty(&self) -> bool {
+        true
+    }
+}
+
+impl<W: super::Writer> DataStream<W> for () {
+    fn to_writer(&self, _writer: &mut W) -> Result<(), <W as super::Writer>::Error> {
+        Ok(())
+    }
+}
+
 impl<T: DataSource + ?Sized> DataSource for &T {
     fn len(&self) -> usize {
         T::len(&**self)
@@ -129,7 +145,7 @@ mod tuple_impls {
                 fn is_empty(&self) -> bool {
                     #[allow(non_snake_case)]
                     let ($($t),+) = self;
-                    true $( || $t.is_empty())+
+                    true $( && $t.is_empty())+
                 }
             }
             impl<W: crate::command::Writer, $($t: DataStream<W>),+> DataStream<W> for ($($t),+) {

--- a/src/command/instruction.rs
+++ b/src/command/instruction.rs
@@ -1,23 +1,3 @@
-// #[derive(Copy, Clone, Eq, PartialEq)]
-// pub struct BinaryInstruction(u8);
-// impl fmt::Debug for BinaryInstruction {
-//     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-//         f.write_fmt(format_args!("'{:X}'", self.0))
-//     }
-// }
-
-// impl From<u8> for BinaryInstruction {
-//     fn from(ins: u8) -> Self {
-//         Self(ins)
-//     }
-// }
-
-// impl From<BinaryInstruction> for u8 {
-//     fn from(ins: BinaryInstruction) -> u8 {
-//         ins.0
-//     }
-// }
-
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Instruction {
     Select,

--- a/src/command/instruction.rs
+++ b/src/command/instruction.rs
@@ -1,3 +1,5 @@
+use core::ops::{BitAnd, BitOr};
+
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Instruction {
     Select,
@@ -52,6 +54,24 @@ impl From<Instruction> for u8 {
             Instruction::WriteBinary => 0xd0,
             Instruction::Unknown(ins) => ins,
         }
+    }
+}
+
+impl BitAnd for Instruction {
+    type Output = Self;
+    fn bitand(self, rhs: Self) -> Self::Output {
+        let rhs: u8 = rhs.into();
+        let this: u8 = self.into();
+        (this & rhs).into()
+    }
+}
+
+impl BitOr for Instruction {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self::Output {
+        let rhs: u8 = rhs.into();
+        let this: u8 = self.into();
+        (this | rhs).into()
     }
 }
 

--- a/src/command/writer.rs
+++ b/src/command/writer.rs
@@ -34,7 +34,7 @@ pub trait Writer {
     fn write_all(&mut self, data: &[u8]) -> Result<(), Self::Error> {
         let mut offset = 0;
         while offset < data.len() {
-            offset += self.write(data)?;
+            offset += self.write(&data[offset..])?;
         }
         Ok(())
     }

--- a/src/command/writer.rs
+++ b/src/command/writer.rs
@@ -1,0 +1,76 @@
+use core::convert::Infallible;
+use core::fmt::{Debug, Display};
+use core::mem::replace;
+
+pub trait Writer {
+    type Error: Debug + Display;
+
+    fn write(&mut self, data: &[u8]) -> Result<usize, Self::Error>;
+
+    fn remaining_len(&self) -> usize;
+
+    /// data must be smaller than [`remaining_len`](Writer::remaining_len)
+    fn write_all(&mut self, data: &[u8]) -> Result<(), Self::Error> {
+        debug_assert!(data.len() <= self.remaining_len());
+        let mut offset = 0;
+        while offset < data.len() {
+            offset += self.write(data)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a> Writer for &'a mut [u8] {
+    type Error = Infallible;
+    fn write(&mut self, data: &[u8]) -> Result<usize, Infallible> {
+        let amt = data.len().min(self.len());
+        let (a, b) = replace(self, &mut []).split_at_mut(amt);
+        a.copy_from_slice(&data[..amt]);
+        *self = b;
+        Ok(amt)
+    }
+
+    fn remaining_len(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<const N: usize> Writer for heapless::Vec<u8, N> {
+    type Error = Infallible;
+    fn write(&mut self, data: &[u8]) -> Result<usize, Infallible> {
+        let written_len = data.len().min(self.capacity() - self.len());
+        self.extend_from_slice(&data[..written_len]).unwrap();
+        Ok(written_len)
+    }
+
+    fn remaining_len(&self) -> usize {
+        self.capacity() - self.len()
+    }
+}
+
+#[cfg(feature = "heapless_bytes")]
+impl<const N: usize> Writer for heapless_bytes::Bytes<N> {
+    type Error = Infallible;
+    fn write(&mut self, data: &[u8]) -> Result<usize, Infallible> {
+        let written_len = data.len().min(self.capacity() - self.len());
+        self.extend_from_slice(&data[..written_len]).unwrap();
+        Ok(written_len)
+    }
+
+    fn remaining_len(&self) -> usize {
+        self.capacity() - self.len()
+    }
+}
+
+#[cfg(any(feature = "std", test))]
+impl Writer for Vec<u8> {
+    type Error = Infallible;
+    fn write(&mut self, data: &[u8]) -> Result<usize, Infallible> {
+        self.extend_from_slice(data);
+        Ok(data.len())
+    }
+
+    fn remaining_len(&self) -> usize {
+        usize::MAX
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ mod tests {
         assert_eq!(u8::from(command.instruction()), ins);
         assert_eq!(command.p1, p1);
         assert_eq!(command.p2, p2);
-        assert!(!command.extended);
+        assert!(!command.extended());
         assert_eq!(command.data().as_slice(), &data.0);
         assert_eq!(
             command.expected(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(test), no_std)]
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 
 #[macro_use]
 extern crate delog;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod response;
 pub use aid::{Aid, App};
 pub use command::{Command, Instruction};
 pub use response::{Response, Status};
+pub mod tlv;
 
 #[cfg(test)]
 mod tests {

--- a/src/tlv.rs
+++ b/src/tlv.rs
@@ -110,7 +110,7 @@ pub fn get_do<'input>(tag_path: &[Tag], data: &'input [u8]) -> Option<&'input [u
 }
 
 /// Returns (tag, data, remainder)
-fn take_do(data: &[u8]) -> Option<(Tag, &[u8], &[u8])> {
+pub fn take_do(data: &[u8]) -> Option<(Tag, &[u8], &[u8])> {
     let (tag, remainder) = take_tag(data)?;
     let (len, remainder) = take_len(remainder)?;
     if remainder.len() < len {
@@ -184,6 +184,12 @@ fn serialize_len(len: usize) -> Option<heapless::Vec<u8, 3>> {
 pub struct Tlv<S> {
     tag: Tag,
     data: S,
+}
+
+impl<S> Tlv<S> {
+    pub fn new(tag: Tag, data: S) -> Self {
+        Self { tag, data }
+    }
 }
 
 impl<S: DataSource> DataSource for Tlv<S> {

--- a/src/tlv.rs
+++ b/src/tlv.rs
@@ -1,6 +1,6 @@
 //! BER-TLV writer and parser
 
-use crate::command::{writer::Error as _, DataSource, Writer};
+use crate::command::{writer::Error as _, DataSource, DataStream, Writer};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub struct Tag([u8; 3]);
@@ -169,7 +169,7 @@ pub struct Tlv<S> {
     data: S,
 }
 
-impl<W: Writer, S: DataSource<W>> DataSource<W> for Tlv<S> {
+impl<S: DataSource> DataSource for Tlv<S> {
     fn len(&self) -> usize {
         let tag = self.tag.serialize();
         let len = serialize_len(self.data.len())
@@ -178,6 +178,12 @@ impl<W: Writer, S: DataSource<W>> DataSource<W> for Tlv<S> {
         tag.len() + len + self.data.len()
     }
 
+    fn is_empty(&self) -> bool {
+        false
+    }
+}
+
+impl<W: Writer, S: DataStream<W>> DataStream<W> for Tlv<S> {
     fn to_writer(&self, writer: &mut W) -> Result<(), <W as Writer>::Error> {
         writer.write_all(&self.tag.serialize())?;
         writer.write_all(

--- a/src/tlv.rs
+++ b/src/tlv.rs
@@ -5,9 +5,34 @@ use crate::command::{writer::Error as _, DataSource, DataStream, Writer};
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub struct Tag([u8; 3]);
 
+impl Tag {
+    pub const fn from_u8(value: u8) -> Self {
+        Tag([value, 0, 0])
+    }
+
+    pub const fn from_u16(value: u16) -> Self {
+        Tag::from_2(value.to_be_bytes())
+    }
+
+    pub const fn from_2([b1, b2]: [u8; 2]) -> Self {
+        if b1 == 0 {
+            Tag([b2, 0, 0])
+        } else {
+            Tag([b1, b2, 0])
+        }
+    }
+    pub const fn from_3([b1, b2, b3]: [u8; 3]) -> Self {
+        if b1 == 0 {
+            Self::from_2([b2, b3])
+        } else {
+            Tag([b1, b2, b3])
+        }
+    }
+}
+
 impl From<u8> for Tag {
     fn from(value: u8) -> Self {
-        Tag([value, 0, 0])
+        Self::from_u8(value)
     }
 }
 
@@ -24,22 +49,14 @@ impl From<[u8; 1]> for Tag {
 }
 
 impl From<[u8; 2]> for Tag {
-    fn from([b1, b2]: [u8; 2]) -> Self {
-        if b1 == 0 {
-            Tag([b2, 0, 0])
-        } else {
-            Tag([b1, b2, 0])
-        }
+    fn from(value: [u8; 2]) -> Self {
+        Self::from_2(value)
     }
 }
 
 impl From<[u8; 3]> for Tag {
-    fn from([b1, b2, b3]: [u8; 3]) -> Self {
-        if b1 == 0 {
-            [b2, b3].into()
-        } else {
-            Tag([b1, b2, 0])
-        }
+    fn from(value: [u8; 3]) -> Self {
+        Self::from_3(value)
     }
 }
 

--- a/src/tlv.rs
+++ b/src/tlv.rs
@@ -92,12 +92,12 @@ impl Tag {
     }
 }
 
-pub fn get_do<'input>(tag_path: &[Tag], data: &'input [u8]) -> Option<&'input [u8]> {
+pub fn get_data_object<'input>(tag_path: &[Tag], data: &'input [u8]) -> Option<&'input [u8]> {
     let mut to_ret = data;
     let mut remainder = data;
     for tag in tag_path {
         loop {
-            let (cur_tag, cur_value, cur_remainder) = take_do(remainder)?;
+            let (cur_tag, cur_value, cur_remainder) = take_data_object(remainder)?;
             remainder = cur_remainder;
             if *tag == cur_tag {
                 to_ret = cur_value;
@@ -110,7 +110,7 @@ pub fn get_do<'input>(tag_path: &[Tag], data: &'input [u8]) -> Option<&'input [u
 }
 
 /// Returns (tag, data, remainder)
-pub fn take_do(data: &[u8]) -> Option<(Tag, &[u8], &[u8])> {
+pub fn take_data_object(data: &[u8]) -> Option<(Tag, &[u8], &[u8])> {
     let (tag, remainder) = take_tag(data)?;
     let (len, remainder) = take_len(remainder)?;
     if remainder.len() < len {
@@ -226,17 +226,17 @@ mod tests {
     #[test]
     fn dos() {
         assert_eq!(
-            get_do(&[0x02u16].map(Tag::from), &hex!("02 02 1DB9 02 02 1DB9")),
+            get_data_object(&[0x02u16].map(Tag::from), &hex!("02 02 1DB9 02 02 1DB9")),
             Some(hex!("1DB9").as_slice())
         );
         assert_eq!(
-            get_do(&[0xA6u16, 0x7F49, 0x86].map(Tag::from), &hex!("A6 26 7F49 23 86 21 04 2525252525252525252525252525252525252525252525252525252525252525")),
+            get_data_object(&[0xA6u16, 0x7F49, 0x86].map(Tag::from), &hex!("A6 26 7F49 23 86 21 04 2525252525252525252525252525252525252525252525252525252525252525")),
             Some(hex!("04 2525252525252525252525252525252525252525252525252525252525252525").as_slice())
         );
 
         // Multiple nested
         assert_eq!(
-            get_do(&[0xA6u16, 0x7F49, 0x86].map(Tag::from), &hex!("A6 2A 02 02 DEAD 7F49 23 86 21 04 2525252525252525252525252525252525252525252525252525252525252525")),
+            get_data_object(&[0xA6u16, 0x7F49, 0x86].map(Tag::from), &hex!("A6 2A 02 02 DEAD 7F49 23 86 21 04 2525252525252525252525252525252525252525252525252525252525252525")),
             Some(hex!("04 2525252525252525252525252525252525252525252525252525252525252525").as_slice())
         );
     }

--- a/src/tlv.rs
+++ b/src/tlv.rs
@@ -1,0 +1,170 @@
+//! BER-TLV writer and parser
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub struct Tag([u8; 3]);
+
+impl From<u8> for Tag {
+    fn from(value: u8) -> Self {
+        Tag([value, 0, 0])
+    }
+}
+
+impl From<u16> for Tag {
+    fn from(value: u16) -> Self {
+        value.to_be_bytes().into()
+    }
+}
+
+impl From<[u8; 1]> for Tag {
+    fn from([value]: [u8; 1]) -> Self {
+        value.into()
+    }
+}
+
+impl From<[u8; 2]> for Tag {
+    fn from([b1, b2]: [u8; 2]) -> Self {
+        if b1 == 0 {
+            Tag([b2, 0, 0])
+        } else {
+            Tag([b1, b2, 0])
+        }
+    }
+}
+
+impl From<[u8; 3]> for Tag {
+    fn from([b1, b2, b3]: [u8; 3]) -> Self {
+        if b1 == 0 {
+            [b2, b3].into()
+        } else {
+            Tag([b1, b2, 0])
+        }
+    }
+}
+
+impl Tag {
+    pub fn serialize(&self) -> heapless::Vec<u8, 3> {
+        let [b1, b2, b3] = self.0;
+        if b1 == 0 {
+            if b2 == 0 {
+                debug_assert_ne!(b3 & 0b11111, 0b11111, "Invalid encoding for 1 byte tag");
+                heapless::Vec::try_from([b3].as_slice()).unwrap()
+            } else {
+                debug_assert_eq!(
+                    b3 & 0b11111,
+                    0b11111,
+                    "Invalid encoding for first byte of tag"
+                );
+                debug_assert!(
+                    (0x1F..=0x7F).contains(&b3),
+                    "Invalid encoding for first byte of tag"
+                );
+                heapless::Vec::try_from([b2, b3].as_slice()).unwrap()
+            }
+        } else {
+            debug_assert_eq!(
+                b1 & 0b11111,
+                0b11111,
+                "Invalid encoding for first byte of tag"
+            );
+            debug_assert!(b2 > 0x80);
+            debug_assert!((0x00..0x7F).contains(&b3));
+            heapless::Vec::try_from([b1, b2, b3].as_slice()).unwrap()
+        }
+    }
+}
+
+pub fn get_do<'input>(tag_path: &[Tag], data: &'input [u8]) -> Option<&'input [u8]> {
+    let mut to_ret = data;
+    let mut remainder = data;
+    for tag in tag_path {
+        loop {
+            let (cur_tag, cur_value, cur_remainder) = take_do(remainder)?;
+            remainder = cur_remainder;
+            if *tag == cur_tag {
+                to_ret = cur_value;
+                remainder = cur_value;
+                break;
+            }
+        }
+    }
+    Some(to_ret)
+}
+
+/// Returns (tag, data, remainder)
+fn take_do(data: &[u8]) -> Option<(Tag, &[u8], &[u8])> {
+    let (tag, remainder) = take_tag(data)?;
+    let (len, remainder) = take_len(remainder)?;
+    if remainder.len() < len {
+        None
+    } else {
+        let (value, remainder) = remainder.split_at(len);
+        Some((tag, value, remainder))
+    }
+}
+
+// See
+// https://www.emvco.com/wp-content/uploads/2017/05/EMV_v4.3_Book_3_Application_Specification_20120607062110791.pdf
+// Annex B1
+pub fn take_tag(data: &[u8]) -> Option<(Tag, &[u8])> {
+    let b1 = *data.first()?;
+    if (b1 & 0x1f) == 0x1f {
+        let b2 = *data.get(1)?;
+        if (0x00..0x1E).contains(&b2) || b2 == 0x80 {
+            return None;
+        }
+
+        if (0x81..0xFF).contains(&b2) {
+            let b3 = *data.get(2)?;
+            if (0x81..0xFF).contains(&b3) {
+                return None;
+            }
+
+            Some((Tag([b1, b2, b3]), &data[3..]))
+        } else {
+            Some((Tag([b1, b2, 0]), &data[2..]))
+        }
+    } else {
+        Some((Tag([b1, 0, 0]), &data[1..]))
+    }
+}
+
+pub fn take_len(data: &[u8]) -> Option<(usize, &[u8])> {
+    let l1 = *data.first()?;
+    if l1 <= 0x7F {
+        Some((l1 as usize, &data[1..]))
+    } else if l1 == 0x81 {
+        Some((*data.get(1)? as usize, &data[2..]))
+    } else {
+        if l1 != 0x82 {
+            return None;
+        }
+        let l2 = *data.get(1)?;
+        let l3 = *data.get(2)?;
+        let len = u16::from_be_bytes([l2, l3]) as usize;
+        Some((len, &data[3..]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hex_literal::hex;
+
+    #[test]
+    fn dos() {
+        assert_eq!(
+            get_do(&[0x02u16].map(Tag::from), &hex!("02 02 1DB9 02 02 1DB9")),
+            Some(hex!("1DB9").as_slice())
+        );
+        assert_eq!(
+            get_do(&[0xA6u16, 0x7F49, 0x86].map(Tag::from), &hex!("A6 26 7F49 23 86 21 04 2525252525252525252525252525252525252525252525252525252525252525")),
+            Some(hex!("04 2525252525252525252525252525252525252525252525252525252525252525").as_slice())
+        );
+
+        // Multiple nested
+        assert_eq!(
+            get_do(&[0xA6u16, 0x7F49, 0x86].map(Tag::from), &hex!("A6 2A 02 02 DEAD 7F49 23 86 21 04 2525252525252525252525252525252525252525252525252525252525252525")),
+            Some(hex!("04 2525252525252525252525252525252525252525252525252525252525252525").as_slice())
+        );
+    }
+}


### PR DESCRIPTION
This is useful for the tests of opcard and the nitrokey piv application. Having this here, properly implemented and tested is better than a couple helper functions there, and it will also be necessary for SE050 communication.

It is built on top of #12. I'm leaving it as draft until #12 is merged.