### PR TITLE
CommandView: precise lifetime of data

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -119,7 +119,7 @@ impl<'a> CommandView<'a> {
         self.instruction
     }
 
-    pub fn data(&self) -> &[u8] {
+    pub fn data(&self) -> &'a [u8] {
         self.data
     }
 


### PR DESCRIPTION
This makes usage more flexible since the `'a` lifetime is larger than the one associated to `self`.